### PR TITLE
Add blog back button and desktop header navigation

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { CustomMDX } from 'components/mdx';
 import { formatDate, getBlogPosts } from 'app/blog/utils';
 import { baseUrl } from 'app/sitemap';
@@ -39,11 +40,11 @@ export default function Blog({ params }) {
 
 	return (
 		<section>
-			<script
-				type='application/ld+json'
-				suppressHydrationWarning
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
+                        <script
+                                type='application/ld+json'
+                                suppressHydrationWarning
+                                dangerouslySetInnerHTML={{
+                                        __html: JSON.stringify({
 						'@context': 'https://schema.org',
 						'@type': 'BlogPosting',
 						headline: post.metadata.title,
@@ -59,13 +60,19 @@ export default function Blog({ params }) {
 							name: "Laurent's Portfolio",
 						},
 					}),
-				}}
-			/>
+                                }}
+                        />
+                        <Link
+                                href='/blog'
+                                className='inline-block mb-4 text-sm text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-400'
+                        >
+                                back
+                        </Link>
 
-			<div className='p-6 mb-8'>
-				<h1 className='font-semibold text-2xl tracking-tighter mb-4 text-black dark:text-white'>
-					{post.metadata.title}
-				</h1>
+                        <div className='p-6 mb-8'>
+                                <h1 className='font-semibold text-2xl tracking-tighter mb-4 text-black dark:text-white'>
+                                        {post.metadata.title}
+                                </h1>
 
 				<div className='flex items-center mb-6'>
 					<span className='text-xs px-2 py-1 text-black dark:text-white tabular-nums'>

--- a/components/layout/nav.tsx
+++ b/components/layout/nav.tsx
@@ -25,38 +25,60 @@ const navItems = {
 };
 
 export function Navbar() {
-	const pathname = usePathname();
+        const pathname = usePathname();
 
-	return (
-		<aside className='mb-8 md:mb-12'>
-			<div className='lg:sticky lg:top-20'>
-				<nav className='p-2 overflow-x-auto'>
-					<div className='flex flex-row justify-center space-x-1 min-w-full'>
-						{Object.entries(navItems).map(([path, { name }]) => {
-							const isActive =
-								pathname === path ||
-								(path === '/blog' && pathname.startsWith('/blog'));
+        return (
+                <>
+                        {/* Mobile navigation */}
+                        <aside className='mb-8 md:mb-12 md:hidden'>
+                                <div className='lg:sticky lg:top-20'>
+                                        <nav className='p-2 overflow-x-auto'>
+                                                <div className='flex flex-row justify-center space-x-1 min-w-full'>
+                                                        {Object.entries(navItems).map(([path, { name }]) => {
+                                                                const isActive =
+                                                                        pathname === path ||
+                                                                        (path === '/blog' && pathname.startsWith('/blog'));
 
-							if (isActive) {
-								return null;
-							}
+                                                                if (isActive) {
+                                                                        return null;
+                                                                }
 
-							return (
-								<Link
-									key={path}
-									href={path}
-									className={`
-										transition-all duration-300 ease-out px-2 py-1.5 md:px-3 md:py-2 text-xs md:text-sm font-medium text-center whitespace-nowrap flex-1 transform hover:scale-105
-										text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-400
-									`}
-								>
-									{name}
-								</Link>
-							);
-						})}
-					</div>
-				</nav>
-			</div>
-		</aside>
-	);
+                                                                return (
+                                                                        <Link
+                                                                                key={path}
+                                                                                href={path}
+                                                                                className={`
+                                                                                        transition-all duration-300 ease-out px-2 py-1.5 md:px-3 md:py-2 text-xs md:text-sm font-medium text-center whitespace-nowrap flex-1 transform hover:scale-105
+                                                                                        text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-400
+                                                                                `}
+                                                                        >
+                                                                                {name}
+                                                                        </Link>
+                                                                );
+                                                        })}
+                                                </div>
+                                        </nav>
+                                </div>
+                        </aside>
+
+                        {/* Desktop navigation */}
+                        <nav className='hidden md:flex justify-center mb-12 space-x-4'>
+                                {Object.entries(navItems).map(([path, { name }]) => (
+                                        <Link
+                                                key={path}
+                                                href={path}
+                                                className={`transition-all duration-300 ease-out px-3 py-2 text-sm font-medium text-center hover:scale-105
+                                                        ${
+                                                                pathname === path ||
+                                                                (path === '/blog' && pathname.startsWith('/blog'))
+                                                                        ? 'text-black dark:text-white underline'
+                                                                        : 'text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-400'
+                                                        }`}
+                                        >
+                                                {name}
+                                        </Link>
+                                ))}
+                        </nav>
+                </>
+        );
 }


### PR DESCRIPTION
## Summary
- add back link on individual blog posts
- show current minimalist header only on mobile
- display full navigation links on larger screens

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c19fea71848323b58798b39b3ec777