### PR TITLE
Add Asapuu Events project to Projects page

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -20,6 +20,19 @@ type Project = {
 
 const projects: Project[] = [
   {
+    name: 'Asapuu Events',
+    tags: [
+      'React',
+      'TypeScript',
+      'Vite',
+      'Cloudflare Workers',
+      'Tailwind CSS',
+      'React Query',
+      'Zustand',
+    ],
+    url: 'https://events.asapuu.com/',
+  },
+  {
     name: 'Subly API',
     tags: ['Bun', 'Hono', 'PostgreSQL', 'TypeScript', 'Drizzle ORM'],
     url: 'https://github.com/laurentcodes/subly-api',


### PR DESCRIPTION
### Motivation
- Add an entry for "Asapuu Events" so the new project is listed on the Projects page.

### Description
- Inserted a new `Project` object for `Asapuu Events` in `app/projects/page.tsx` with tags `['React', 'TypeScript', 'Vite', 'Cloudflare Workers', 'Tailwind CSS', 'React Query', 'Zustand']` and `url` set to `https://events.asapuu.com/`.

### Testing
- Ran `next build` (TypeScript compile) and `npm run lint` to validate the change, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f877f6eb348323b008db11996f060e)