### PR TITLE
Remove JavaScript from site introduction

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
 
         <div className='space-y-4 text-black [html.dark_&]:text-white mb-8'>
           <p>
-            I'm a Software Developer specializing in JavaScript and TypeScript,
+            I'm a Software Developer specializing in TypeScript,
             passionate about crafting innovative solutions through code.
           </p>
 


### PR DESCRIPTION
Keeps TypeScript as the sole specialization language mentioned in the intro paragraph.